### PR TITLE
FixSQL template install for pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(name='snapperdb',
       url='https://github.com/phe-bioinformatics/snapperdb/',
       download_url='https://github.com/phe-bioinformatics/snapperdb/archive/v1.0.4.tar.gz',
       packages=['snapperdb','snapperdb.snpdb','snapperdb.gbru_vcf'],
+      include_package_data=True,
+      package_data={'snpdb': ['snapperdb/snpdb/template_snapperdb_denovo_refs_sql']},
       scripts=['run_snapperdb.py'],
       install_requires=install_requires
      )


### PR DESCRIPTION
`pip` misses "template_snapperdb_denovo_refs_sql" when installing, so new databases aren't created correctly. Quick fix to setup.py to pull it in and put it in the correct location.